### PR TITLE
Support for macOS Big Sur 11.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # TSOEnabler
 
-A kernel extension that enables total store ordering on Apple silicon, with semantics similar to x86_64's memory model. This is normally done by the kernel through modifications to a special register upon exit from the kernel for programs running under Rosetta 2; however, it is possible to enable this for arbitrary processes (on a per-thread basis, technically) as well by modifying the flag for this feature and letting the kernel enable it for us on. Setting this flag on certain processors can only be done on high-performance cores, so as a side effect of enabling TSO the kernel extension will also migrate your code off the efficiency cores permanently. **This extensions hardcodes offsets based on the macOS Big Sur 11.2 Beta (20D5029f) kernel.release.t8020. If you would like to run it on any other computer, you will need to modify these.**
+A kernel extension that enables total store ordering on Apple silicon, with semantics similar to x86_64's memory model. This is normally done by the kernel through modifications to a special register upon exit from the kernel for programs running under Rosetta 2; however, it is possible to enable this for arbitrary processes (on a per-thread basis, technically) as well by modifying the flag for this feature and letting the kernel enable it for us on. Setting this flag on certain processors can only be done on high-performance cores, so as a side effect of enabling TSO the kernel extension will also migrate your code off the efficiency cores permanently.
+
+**This extension hardcodes offsets**, you may need to modify them.
+Currently supported kernels are (select version in `TSOEnabler.c`);
+- macOS Big Sur 11.2 Beta (20D5029f) kernel.release.t8020
+- macOS Big Sur 11.3.1 (20E241) kernel.release.t8101
+
+If your kernel is not supported, see instructions on how to find the `TSO_OFFSET` below.
 
 ## Installation
 
@@ -16,6 +23,50 @@ Supposedly, you should be able to use this if you build and sign the kernel exte
 
 After that try installing the kernel extension again.
 
+## Disabling SIP KEXT
+
+An alternative to lowering the boot security is to disable SIP KEXT altogether.
+
+1. Reboot into recovery.
+2. Terminal.
+3. Run `csrutil enable --without KEXT`
+
 ## Usage
 
 Load the kernel extension with `sudo kextload /Library/Extensions/TSOEnabler.kext`. After that, the `kern.tso_enable` sysctl will be made available to you to read or write. For the reasons described above, you must enable this for all threads of your application if you would like it to work; doing so will also pin these to the high-performance cores of your processor.
+
+## How to find the offsets
+
+The `TSO_OFFSET` can be different for each kernel version and has to be found within the kernel.
+For example, in macOS Big Sur 11.3.1 (20E241) kernel.release.t8101, the offset can be found like this:
+
+1. Disassemble kernel code:
+```
+objdump -D /System/Library/Kernels/kernel.release.t8101 > kernel.lst
+
+```
+2. Find lines where `ACTLR_EL1` is accessed:
+```
+grep -C 20 ACTLR_EL1 kernel.lst | less -N
+```
+
+3. Look for code blocks where `TPIDR_EL1` is accessed immediately before like this:
+
+```
+ 289785 fffffe000720f384: 81 d0 38 d5   mrs     x1, TPIDR_EL1
+ 289786 fffffe000720f388: 20 90 40 f9   ldr     x0, [x1, #288]   ;  <-------- This is the offset
+ 289787 fffffe000720f38c: 80 01 00 b4   cbz     x0, 0xfffffe000720f3bc
+ 289788 fffffe000720f390: 60 f8 3e d5   mrs     x0, S3_6_C15_C8_3
+ 289789 fffffe000720f394: 00 04 1f 12   and     w0, w0, #0x6
+ 289790 fffffe000720f398: e0 17 01 b9   str     w0, [sp, #276]
+ 289791 fffffe000720f39c: a0 f2 3e d5   mrs     x0, S3_6_C15_C2_5
+ 289792 fffffe000720f3a0: e0 4b 03 b9   str     w0, [sp, #840]
+ 289793 fffffe000720f3a4: 20 10 38 d5   mrs     x0, ACTLR_EL1
+ 289794 fffffe000720f3a8: 00 f8 7e 92   and     x0, x0, #0xfffffffffffffffd
+ 289795 fffffe000720f3ac: 00 f0 79 92   and     x0, x0, #0xffffffffffffff8f
+ 289796 fffffe000720f3b0: 9f 3f 03 d5   dsb     sy
+ 289797 fffffe000720f3b4: 20 10 18 d5   msr     ACTLR_EL1, x0
+ 289798 fffffe000720f3b8: df 3f 03 d5   isb
+```
+
+In this case the offset is **288**. Note the offset is given in decimal here (no 0x prefix).

--- a/TSOEnabler/TSOEnabler.c
+++ b/TSOEnabler/TSOEnabler.c
@@ -11,12 +11,31 @@
 #include <sys/sysctl.h>
 #include <sys/systm.h>
 
-#define TSO_OFFSET 0x4e8
+/* supported kernels */
+#define MACOS_11_2_BETA_RELEASE_T8020  1
+#define MACOS_11_3_1_RELEASE_T8101     2
 
+/* kernel selector */
+#define KERN MACOS_11_3_1_RELEASE_T8101
+
+/* 3 constants are kernel dependent.
+ * TSO_OFFSET is mandatory
+ * unslid_printf and unslid_thread_bind_cluster_type only necessary on A12Z
+ */
+
+#if KERN == MACOS_11_3_1_RELEASE_T8101
+#define TSO_OFFSET 288
+#elif KERN == MACOS_11_2_BETA_RELEASE_T8020
+#define TSO_OFFSET 0x4e8
 #define unslid_printf 0xfffffe000724ced0
 #define unslid_thread_bind_cluster_type 0xfffffe000725da04
+#else
+#error "kernel not supported"
+#endif
 
+#ifdef unslid_thread_bind_cluster_type
 static void (*thread_bind_cluster_type)(thread_t, char);
+#endif
 
 static char *get_thread_pointer(void) {
 	char *pointer = NULL;
@@ -27,33 +46,35 @@ static char *get_thread_pointer(void) {
 
 static int sysctl_tso_enable SYSCTL_HANDLER_ARGS {
 	printf("TSOEnabler: got request from %d\n", proc_selfpid());
-	
+
 	char *thread_pointer = get_thread_pointer();
 	if (!thread_pointer) {
 		return KERN_FAILURE;
 	}
-	
+
 	int in;
 	int error = SYSCTL_IN(req, &in, sizeof(in));
-	
+
 	// Write to TSO
 	if (!error && req->newptr) {
 		printf("TSOEnabler: setting TSO to %d\n", in);
 		if ((thread_pointer[TSO_OFFSET] = in)) {
+#ifdef unslid_thread_bind_cluster_type
 			printf("TSOEnabler: binding to performance core\n");
 			thread_bind_cluster_type(current_thread(), 'P');
+#endif
 		}
-	// Read TSO
+		// Read TSO
 	} else if (!error) {
 		int out = thread_pointer[TSO_OFFSET];
 		printf("TSOEnabler: TSO is %d\n", out);
 		error = SYSCTL_OUT(req, &out, sizeof(out));
 	}
-	
+
 	if (error) {
 		printf("TSOEnabler: request failed with error %d\n", error);
 	}
-	
+
 	return error;
 }
 
@@ -62,10 +83,12 @@ SYSCTL_PROC(_kern, OID_AUTO, tso_enable, CTLTYPE_INT | CTLFLAG_RW | CTLFLAG_ANYB
 kern_return_t TSOEnabler_start(kmod_info_t *ki, void *d) {
 	printf("TSOEnabler: TSOEnabler_start()\n");
 	sysctl_register_oid(&sysctl__kern_tso_enable);
+#ifdef unslid_thread_bind_cluster_type
 	// Find thread_bind_cluster_type without PAC yelling at us
 	uintptr_t unauthenticated_printf = (uintptr_t)ptrauth_strip((void *)printf, ptrauth_key_function_pointer);
 	thread_bind_cluster_type = (void (*)(thread_t, char))ptrauth_sign_unauthenticated((void *)(unauthenticated_printf + (unslid_thread_bind_cluster_type - unslid_printf)), ptrauth_key_function_pointer, 0);
 	printf("TSOEnabler: found thread_bind_cluster_type at %p\n", thread_bind_cluster_type);
+#endif
 	return KERN_SUCCESS;
 }
 

--- a/test/tso-test.c
+++ b/test/tso-test.c
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Compile and run:
+ * 	gcc -DTSO=1 -o tso-test tso-test.c -lpthread && ./tso-test
+ * 	gcc -DTSO=0 -o tso-test tso-test.c -lpthread && ./tso-test
+ *
+ * With TSO=0 the assertion should fail.
+ ******************************************************************************/
+#include <stdatomic.h>
+#include <pthread.h>
+#include <sys/sysctl.h>
+#include <assert.h>
+
+#define NITERS 1000000 // number of iterations
+
+atomic_int lock;
+#define lock_acquire() \
+	while(atomic_exchange_explicit(&lock, 1, memory_order_relaxed)) {}
+#define lock_release() atomic_store(&lock, 0)
+
+#ifndef TSO
+#error "compile with -DTSO=1 or -DTSO=0"
+#endif
+static void enable_tso()
+{
+	int enable = TSO;
+	size_t size = sizeof(enable);
+	int err = sysctlbyname("kern.tso_enable", NULL, &size, &enable, size);
+	assert(err == 0);
+}
+
+static unsigned int x;
+static void *run(void *arg)
+{
+	(void) arg;
+	enable_tso();
+	for (int i=0; i < NITERS; i++) {
+		lock_acquire();
+		x++;
+		lock_release();
+	}
+	return 0;
+}
+
+int main()
+{
+	pthread_t t;
+	pthread_create(&t, 0, run, 0);
+	run(0);
+	pthread_join(t, 0);
+	assert(x == 2*NITERS && "TSO is not enabled");
+	return 0;
+}


### PR DESCRIPTION
This PR adds support for macOS Big Sur 11.3.1 (20E241) kernel.release.t8101 and updates the readme with some hints how to find out the TSO_OFFSET. The TSOEnabler.c has now a selector for the kernel version.